### PR TITLE
Cleanup state and account

### DIFF
--- a/core/account.go
+++ b/core/account.go
@@ -5,9 +5,7 @@ import (
 )
 
 var (
-	ErrAccAlreadyExists     = errors.New("Account already exists")
 	ErrUnableToInsertLeaves = errors.New("Unable to insert leaves")
-	EmptyByteSlice          = []byte{}
 )
 
 // Account is the copy of the accounts tree
@@ -35,57 +33,54 @@ type Account struct {
 
 // NewAccount creates a new account
 func NewAccount(id uint64, pubkey []byte, path string) (*Account, error) {
-	newAccount := &Account{
+	node := &Account{
 		ID:        id,
 		PublicKey: pubkey,
 		Path:      path,
 		Type:      TYPE_TERMINAL,
 	}
-	err := newAccount.PopulateHash()
-	if err != nil {
-		return nil, err
-	}
-	return newAccount, nil
+	err := node.PopulateHash()
+	return node, err
 }
 
 func NewAccountNode(path, hash string) *Account {
-	newAccount := &Account{
+	node := &Account{
 		ID:   ZERO,
 		Path: path,
 		Type: TYPE_NON_TERMINAL,
 	}
-	newAccount.UpdatePath(path)
-	newAccount.Hash = hash
-	return newAccount
+	node.UpdatePath(path)
+	node.Hash = hash
+	return node
 }
 
 // NewEmptyAccount creates new empty account which generates zero hash
 func NewEmptyAccount() *Account {
-	return &Account{ID: ZERO, PublicKey: EmptyByteSlice, Type: TYPE_TERMINAL}
+	return &Account{ID: ZERO, PublicKey: []byte{}, Type: TYPE_TERMINAL}
 }
 
-func (p *Account) UpdatePath(path string) {
-	p.Path = path
-	p.Level = uint64(len(path))
+func (node *Account) UpdatePath(path string) {
+	node.Path = path
+	node.Level = uint64(len(path))
 }
 
-func (p *Account) HashToByteArray() ByteArray {
-	ba, err := HexToByteArray(p.Hash)
+func (node *Account) HashToByteArray() ByteArray {
+	ba, err := HexToByteArray(node.Hash)
 	if err != nil {
 		panic(err)
 	}
 	return ba
 }
 
-func (p *Account) PopulateHash() error {
-	if len(p.PublicKey) == 0 {
-		p.Hash = ZeroLeaf.String()
+func (node *Account) PopulateHash() error {
+	if len(node.PublicKey) == 0 {
+		node.Hash = ZeroLeaf.String()
 		return nil
 	}
-	hash, err := Pubkey(p.PublicKey).ToHash()
+	hash, err := Pubkey(node.PublicKey).ToHash()
 	if err != nil {
 		return err
 	}
-	p.Hash = hash
+	node.Hash = hash
 	return nil
 }

--- a/core/state.go
+++ b/core/state.go
@@ -58,7 +58,7 @@ func NewStateNode(path, hash string) *UserState {
 		Type:      TYPE_NON_TERMINAL,
 	}
 	node.UpdatePath(node.Path)
-	node.UpdateHash()
+	node.Hash = hash
 	return node
 }
 

--- a/db/deposit.go
+++ b/db/deposit.go
@@ -80,7 +80,7 @@ func (db *DB) FinaliseDeposits(pathToDepositSubTree uint64, depositRoot core.Byt
 	for i, acc := range accounts {
 		acc.Status = core.STATUS_ACTIVE
 		acc.UpdatePath(terminalNodes[i])
-		acc.CreateAccountHash()
+		acc.UpdateHash()
 		err := db.UpdateState(acc)
 		if err != nil {
 			return err

--- a/db/state.go
+++ b/db/state.go
@@ -102,7 +102,7 @@ func (db *DB) GetStatesAtDepth(depth uint64) ([]core.UserState, error) {
 }
 
 func (db *DB) UpdateState(state core.UserState) error {
-	state.CreateAccountHash()
+	state.UpdateHash()
 	siblings, err := db.GetSiblings(state.Path)
 	if err != nil {
 		return err

--- a/db/state.go
+++ b/db/state.go
@@ -309,10 +309,10 @@ func (db *DB) GetFirstEmptyAccount() (acc core.UserState, err error) {
 	return db.GetAccountByHash(expectedHash.String())
 }
 
-func (db *DB) DeletePendingAccount(ID uint64) error {
-	var account core.UserState
-	if err := db.Instance.Where("account_id = ? AND status = ?", ID, core.STATUS_PENDING).Delete(&account).Error; err != nil {
-		return core.ErrRecordNotFound(fmt.Sprintf("unable to delete record for ID: %v", ID))
+func (db *DB) DeletePendingState(accountID uint64) error {
+	var state core.UserState
+	if err := db.Instance.Where("account_id = ? AND status = ?", accountID, core.STATUS_PENDING).Delete(&state).Error; err != nil {
+		return core.ErrRecordNotFound(fmt.Sprintf("unable to delete record for ID: %v", accountID))
 	}
 	return nil
 }
@@ -332,13 +332,13 @@ func (db *DB) AttachDepositInfo(root core.ByteArray) error {
 	return nil
 }
 
-func (db *DB) GetPendingAccByDepositRoot(root core.ByteArray) ([]core.UserState, error) {
+func (db *DB) GetPendingStateByDepositRoot(root core.ByteArray) ([]core.UserState, error) {
 	// find all accounts with CreatedByDepositSubTree as `root`
-	var pendingAccounts []core.UserState
-	query := db.Instance.Where("created_by_deposit_sub_tree = ? AND status = ?", root.String(), core.STATUS_PENDING).Find(&pendingAccounts)
+	var pendingStates []core.UserState
+	query := db.Instance.Where("created_by_deposit_sub_tree = ? AND status = ?", root.String(), core.STATUS_PENDING).Find(&pendingStates)
 	if err := query.Error; err != nil {
-		return pendingAccounts, err
+		return pendingStates, err
 	}
 
-	return pendingAccounts, nil
+	return pendingStates, nil
 }


### PR DESCRIPTION
- if the intention is to get a non-terminal node, call it a node.
- if the intention is to get a terminal state, call it a state.
- If it belongs to the state tree, rename it from "account" to "state" or "node".