### PR TITLE
Simplify the startup process more

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,6 +20,13 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ROOT_PASSWORD: root
     steps:
 
     - name: Set up Go 1.x
@@ -35,12 +42,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
+      run: go get -v -t -d ./...
 
     - name: Build
       run: make build
@@ -52,3 +54,11 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+    - name: Integration
+      run: |
+        make run-hardhat-node > /dev/null &
+        sleep 3
+        make deploy-hubble-contracts
+        make setup
+        pkill make

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 build-hubble-contracts:
-	cd .contracts/ && npm ci && npm run compile
+	cd .contracts/ && npm ci && npm run generate
+
+run-hardhat-node:
+	cd .contracts/ && npm run node
+
+deploy-hubble-contracts:
+	cd .contracts/ && npm run deploy
 
 build-bindings:
 	go install github.com/ethereum/go-ethereum/cmd/abigen

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,17 @@ buidl: build
 lint:
 	golangci-lint run ./...
 
+run-database:
+	docker run --name=mysql -p 3306:3306 -e MYSQL_ROOT_PASSWORD=root -d mysql
+
 init:
 	./build/hubble init
+
+load:
+	./build/hubble load
+
+create-database:
+	./build/hubble create-database
 
 reset:
 	./build/hubble migration down --all
@@ -35,6 +44,8 @@ migrate-up:
 
 migrate-down:
 	./build/hubble migration down --all
+
+setup: build init load create-database migrate-up
 
 start:
 	mkdir -p logs &

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/hex"
 	"strconv"
 
 	"github.com/BOPR/common"
@@ -16,12 +15,6 @@ func initCmd() *cobra.Command {
 		Short: "Initialises Configration for BOPR",
 		Run: func(cmd *cobra.Command, args []string) {
 			defaultConfig := config.GetDefaultConfig()
-			operatorKey, err := config.GenOperatorKey()
-			common.PanicIfError(err)
-			defaultConfig.OperatorKey = hex.EncodeToString(operatorKey)
-			address, err := config.PrivKeyStringToAddress(hex.EncodeToString(operatorKey))
-			common.PanicIfError(err)
-			defaultConfig.OperatorAddress = address.String()
 			config.WriteConfigFile("./config.toml", &defaultConfig)
 		},
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/BOPR/common"
 	"github.com/BOPR/config"
 	"github.com/spf13/cobra"
+)
+
+const (
+	defaultGenesisPath = ".contracts/genesis.json"
 )
 
 // initCmd generated init command to initialise the config file
@@ -27,7 +32,15 @@ func configureGenesisCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg, err := config.ParseConfig()
 			common.PanicIfError(err)
-			genesis, err := config.ReadGenesisFile(args[0])
+			path := ""
+			if len(args) == 0 {
+				path = defaultGenesisPath
+			} else {
+				path = args[0]
+			}
+			fmt.Printf("Loading genesis from %s\n", path)
+
+			genesis, err := config.ReadGenesisFile(path)
 			common.PanicIfError(err)
 
 			common.PanicIfError(genesis.Validate())

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -70,8 +70,8 @@ func main() {
 
 	executor := Executor{rootCmd, os.Exit}
 	if err = executor.Command.Execute(); err != nil {
-		fmt.Println("Error while executing command", err)
-		return
+		fmt.Fprintln(os.Stderr, "Error while executing command", err)
+		os.Exit(1)
 	}
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -150,10 +150,6 @@ func createDatabase() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringP(FlagDatabaseName, "", "", "--dbname=<database-name>")
-	err := cmd.MarkFlagRequired(FlagDatabaseName)
-	if err != nil {
-		panic(err)
-	}
+	cmd.Flags().StringP(FlagDatabaseName, "", config.DATABASENAME, "--dbname=<database-name>")
 	return cmd
 }

--- a/config/config.go
+++ b/config/config.go
@@ -92,8 +92,9 @@ func GetDefaultConfig() Configuration {
 		MassMigration:          ethCmn.Address{}.String(),
 		Create2Transfer:        ethCmn.Address{}.String(),
 
-		OperatorKey:     "",
-		OperatorAddress: "",
+		// Default Account #0 from hardhat. DO NOT USE IN PRODUCTION
+		OperatorKey:     "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+		OperatorAddress: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
 
 		MaxTreeDepth:      32,
 		MaxDepositSubtree: 1,
@@ -162,15 +163,6 @@ func SetOperatorKeys(privKeyStr string) error {
 	OperatorPubKey = ecsdaPubKey
 	OperatorAddress = crypto.PubkeyToAddress(*OperatorPubKey)
 	return nil
-}
-
-func GenOperatorKey() ([]byte, error) {
-	privKey, err := crypto.GenerateKey()
-	if err != nil {
-		return nil, err
-	}
-
-	return crypto.FromECDSA(privKey), nil
 }
 
 // PrivKeyStringToAddress convert private key to public key

--- a/config/config.go
+++ b/config/config.go
@@ -75,7 +75,7 @@ func GetDefaultConfig() Configuration {
 		DB:                     DefaultDB,
 		DBURL:                  GetDBURL(),
 		Trace:                  false,
-		DBLogMode:              true,
+		DBLogMode:              false,
 		EthRPC:                 DefaultEthRPC,
 		TxsPerCommitment:       2,
 		MaxCommitmentsPerBatch: 100,


### PR DESCRIPTION
1. We removed arguments that are not really required manual input. Set default values for them
2. We exploit the fixed relative path defined by the submodule. We can run more commands with default paths.
3. `make setup` is all you need for the commander
4. add integrated build test in CI that's tested with deployed contracts.

- add `make run-hardhat-node` and `make deploy-hubble-contracts`
- genesis path argument is not required in `hubble load`
- database name is not required in `hubble load`
- OperatorKey is no longer needs to be manually assigned. Use the hardhat node default one. We should design secure import from the keystore in the long run 