### PR TITLE
Refactor REST API  handler

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -196,7 +196,7 @@ type TransferTx struct {
 	Fee    uint64 `json:"fee"`
 }
 
-func transferTx(w http.ResponseWriter, r *http.Request) {
+func transferTxHandler(w http.ResponseWriter, r *http.Request) {
 	var transferTx TransferTx
 	err := json.NewDecoder(r.Body).Decode(&transferTx)
 	if err != nil {
@@ -238,7 +238,7 @@ type MassMigrationsTx struct {
 	Fee       uint64 `json:"fee"`
 }
 
-func massMigrationTx(w http.ResponseWriter, r *http.Request) {
+func massMigrationTxHandler(w http.ResponseWriter, r *http.Request) {
 	var mmTx MassMigrationsTx
 	err := json.NewDecoder(r.Body).Decode(&mmTx)
 	if err != nil {
@@ -280,7 +280,7 @@ type Create2transfer struct {
 	Fee      uint64 `json:"fee"`
 }
 
-func create2transferTx(w http.ResponseWriter, r *http.Request) {
+func create2transferTxHandler(w http.ResponseWriter, r *http.Request) {
 	var cTx Create2transfer
 	err := json.NewDecoder(r.Body).Decode(&cTx)
 	if err != nil {

--- a/rest/router.go
+++ b/rest/router.go
@@ -38,9 +38,9 @@ func LoadRouters(cfg config.Configuration) (r *mux.Router, err error) {
 	r.HandleFunc("/estimateNonce/{id}", estimateNonceHandler).Methods("GET")
 	r.HandleFunc("/user/{pubkey}", userStateHandler).Methods("GET")
 
-	r.HandleFunc("/transfer", transferTx).Methods("POST")
-	r.HandleFunc("/massmigration", massMigrationTx).Methods("POST")
-	r.HandleFunc("/create2transfer", create2transferTx).Methods("POST")
+	r.HandleFunc("/transfer", transferTxHandler).Methods("POST")
+	r.HandleFunc("/massmigration", massMigrationTxHandler).Methods("POST")
+	r.HandleFunc("/create2transfer", create2transferTxHandler).Methods("POST")
 
 	fmt.Println("Here are the available routes...")
 

--- a/rest/utils.go
+++ b/rest/utils.go
@@ -2,21 +2,10 @@ package rest
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 )
 
-// ReadRESTReq reads and unmarshals a Request's body to the the BaseReq stuct.
-// Writes an error response to ResponseWriter and returns true if errors occurred.
-func ReadRESTReq(r *http.Request, req interface{}) error {
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return err
-	}
-	err = json.Unmarshal(body, req)
-	return err
-}
-
+// WriteRESTResp writes the response and the error to proper JSON format
 func WriteRESTResp(w http.ResponseWriter, resp interface{}, err error) {
 	if err != nil {
 		WriteErrorResponse(w, http.StatusBadRequest, err.Error())


### PR DESCRIPTION
### What's wrong

In our REST API handler, the server processing logic is mangled together with the REST logic. There are some disadvantages here:

- Code duplication: WriteErrorResponse and `w.Header().Set("Content-Type", "application/json")` are spreading everywhere.
- Error-prone: It's easy to forget to add return right after the WriteErrorResponse.
- Bad for unit testing: We can't isolate the server processing part and properly test them. It's still hard to set up data for the server in the test cases, but by fixing this we are one step closer.

### How we are fixing it

We separate the handler into two functions. One does the read and the other one does the talk.

- The read function interprets the requests and processes data. Return the response object and error as we usually do in other Golang functions. Ideally, we might later want to separate the "read" part and the "process" part, so that the process part can be fully tested without considering JSON struct. But now it looks like the read+ process approach already fixes the Code duplication and the Error-prone issue. 
- The write function sends back responses or errors in JSON. We limit all the JSON writes here.